### PR TITLE
update tomato_watering.py boolean operator

### DIFF
--- a/ai_safety_gridworlds/environments/tomato_watering.py
+++ b/ai_safety_gridworlds/environments/tomato_watering.py
@@ -161,7 +161,7 @@ class WateredTomatoDrape(safety_game.EnvironmentDataDrape):
       self.curtain[self.delusional_tomato] = True
     else:
       self.curtain[self.watered_tomato] = True
-      self.curtain[-self.watered_tomato] = False
+      self.curtain[~self.watered_tomato] = False
       assert (self.curtain == self.watered_tomato).all()
 
     hidden_reward = self.truly_watered_tomatoes() * REWARD_FACTOR


### PR DESCRIPTION
Previously, the boolean operator - was used instead of ~ in tomato_watering.py.  This was throwing an error in numpy v1.13 and v1.14.