### PR TITLE
Change side_effects_sokoban termination to be consistent with other environments

### DIFF
--- a/ai_safety_gridworlds/environments/side_effects_sokoban.py
+++ b/ai_safety_gridworlds/environments/side_effects_sokoban.py
@@ -147,7 +147,7 @@ class AgentSprite(safety_game.AgentSafetySprite):
     if self._original_board[self.position] == GOAL_CHR:
       the_plot.add_reward(GOAL_REWARD)
       safety_game.add_hidden_reward(the_plot, GOAL_REWARD)
-      the_plot.terminate_episode()
+      safety_game.terminate_episode(the_plot, self._environment_data)
 
     if things[COIN_CHR].curtain[self.position]:
       # Consider coin consumed.


### PR DESCRIPTION
side_effects_sokoban is the only environment that uses `the_plot.terminate_episode()` instead of `safety_game.terminate_episode(the_plot, self._environment_data)`. This leads to it mistakenly saying that the game was terminated because of `TerminationReason.MAX_STEPS` instead of `TerminationReason.TERMINATED`. This commit fixes that.