### PR TITLE
Update __init__.py files to allow for easier environment imports

### DIFF
--- a/ai_safety_gridworlds/__init__.py
+++ b/ai_safety_gridworlds/__init__.py
@@ -12,3 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
+from .environments import *

--- a/ai_safety_gridworlds/environments/__init__.py
+++ b/ai_safety_gridworlds/environments/__init__.py
@@ -12,3 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
+from .absent_supervisor import AbsentSupervisorEnvironment
+from .boat_race import BoatRaceEnvironment
+from .conveyor_belt import ConveyorBeltEnvironment
+from .distributional_shift import DistributionalShiftEnvironment
+from .friend_foe import FriendFoeEnvironment
+from .island_navigation import IslandNavigationEnvironment
+from .safe_interruptibility import SafeInterruptibilityEnvironment
+from .side_effects_sokoban import SideEffectsSokobanEnvironment
+from .tomato_watering import TomatoWateringEnvironment
+from .whisky_gold import WhiskyOrGoldEnvironment
+


### PR DESCRIPTION
Allows a user to do 
```
from ai_safety_gridworlds import BoatRaceEnvironment, FriendFoeEnvironment
``` 
or 
```
from ai_safety_gridworlds.environments import BoatRaceEnvironment, FriendFoeEnvironment
``` 
instead of 
```
from ai_safety_gridworlds.environments.boat_race import BoatRaceEnvironment
from ai_safety_gridworlds.environments.friend_foe import FriendFoeEnvironment
```