### PR TITLE
Fix a bug to work with the latest Pycolab

### DIFF
--- a/ai_safety_gridworlds/environments/shared/safety_ui.py
+++ b/ai_safety_gridworlds/environments/shared/safety_ui.py
@@ -169,7 +169,7 @@ class SafetyCursesUi(human_ui.CursesUi):
     # Use undistilled observations.
     observation = self._game._board  # pylint: disable=protected-access
     if self._repainter: observation = self._repainter(observation)
-    self._display(screen, observation, self._env.episode_return,
+    self._display(screen, [observation], self._env.episode_return,
                   elapsed=datetime.timedelta())
 
     # Oh boy, play the game!
@@ -197,7 +197,7 @@ class SafetyCursesUi(human_ui.CursesUi):
       # Update the game display, regardless of whether we've called the game's
       # play() method.
       elapsed = datetime.datetime.now() - self._start_time
-      self._display(screen, observation, self._env.episode_return, elapsed)
+      self._display(screen, [observation], self._env.episode_return, elapsed)
 
       # Update game console message buffer with new messages from the game.
       self._update_game_console(


### PR DESCRIPTION
Error snapshot:
`$ python ai_safety_gridworlds/environments/whisky_gold.py 
Traceback (most recent call last):
  File "ai_safety_gridworlds/environments/whisky_gold.py", line 217, in <module>
    app.run(main)
  File "/Library/Python/2.7/site-packages/absl/app.py", line 300, in run
    _run_main(main, args)
  File "/Library/Python/2.7/site-packages/absl/app.py", line 251, in _run_main
    sys.exit(main(argv))
  File "ai_safety_gridworlds/environments/whisky_gold.py", line 214, in main
    ui.play(env)
  File "/Users/someuser/Documents/ai-safety-gridworlds/ai_safety_gridworlds/environments/shared/safety_ui.py", line 86, in play
    curses.wrapper(self._init_curses_and_play)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/curses/wrapper.py", line 43, in wrapper
    return func(stdscr, *args, **kwds)
  File "/Users/someuser/Documents/ai-safety-gridworlds/ai_safety_gridworlds/environments/shared/safety_ui.py", line 173, in _init_curses_and_play
    elapsed=datetime.timedelta())
  File "/Users/someuser/Documents/ai-safety-gridworlds/pycolab/human_ui.py", line 334, in _display
    for row, board_line in enumerate(observation.board, start=1):
AttributeError: 'numpy.ndarray' object has no attribute 'board'`

As per changes to the parameter of the _display function in human_ui.py in Pycolab repo (detailed diff at: [diff for 9eb0d5b5ea6e9cc6c1aa02490748ff2c6034d6c0](https://github.com/deepmind/pycolab/commit/9eb0d5b5ea6e9cc6c1aa02490748ff2c6034d6c0#diff-f680786bf17baf236083d970761a5625R331), human_ui.py, line 331), the observation parameter shall be changed to a list of observations.